### PR TITLE
Ignore flake8 W503 check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -43,7 +43,7 @@
 - id: flake8-lint
   name: flake8-lint
   description: '`flake8` is a command-line utility for enforcing style consistency across Python projects.'
-  entry: 'flake8 --ignore=E501'
+  entry: 'flake8 --ignore=E501,W503'
   language: system
   files: \.py$
 


### PR DESCRIPTION
`W503` and `W504` are mutually exclusive checks from `flake8`. `W504` is the preferred way as of now.

Ref: https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
Ref: https://www.flake8rules.com/rules/W504.html

Task Link: N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Developer Checklist
- [ ] My change requires a change to the documentation.
- [x] I have updated my branch with the latest changes in master.
- [x] I have communicated with the team any changes that might affect work in progress. 
- [ ] I have updated Trello to reflect current state of the feature. 

## Documentation Checklist
- [ ] I have updated the necessary README's
- [ ] I have updated the Runbook

## Description of Changes
- Ignore W503 check from `flake8`

## Context
-  Code linter not passing since it currently checks for both W503 and W504 which is mutually exclusive. 

```
To solve this readability problem, mathematicians and their publishers follow the opposite convention. Donald Knuth explains the traditional rule in his Computers and Typesetting series: "Although formulas within a paragraph always break after binary operations and relations, displayed formulas always break before binary operations" [3].

Following the tradition from mathematics usually results in more readable code:

# Correct:
# easy to match operators with operands
income = (gross_wages
          + taxable_interest
          + (dividends - qualified_dividends)
          - ira_deduction
          - student_loan_interest)

In Python code, it is permissible to break before or after a binary operator, as long as the convention is consistent locally. For new code Knuth's style is suggested.
```

## Description of Testing Process
- Verified locally
