### PR TITLE
Feature to find print keyword in the repo code.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,5 @@ repos:
     -   id: flake8-lint
     -   id: security-check
     -   id: check-prtemplate
+    -   id: check-print-keyword
+    

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -52,3 +52,9 @@
   description: Validate for PR Template file presence
   entry: hooks/scripts/check-prtemplate.sh
   language: script
+
+- id: check-print-keyword
+  name: Check for Print keyword
+  description: Validate for print keyword in the code
+  entry: hooks/scripts/check-print-keyword.sh
+  language: script

--- a/.pre-commit-pr-hooks.yaml
+++ b/.pre-commit-pr-hooks.yaml
@@ -9,3 +9,4 @@ repos:
     -   id: flake8-lint
     -   id: security-check
     -   id: check-prtemplate
+    -   id: check-print-keyword

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Following are the available hooks -
 - id: check-prtemplate
   description: Validate for PR template file presence
 
+- id: check-print-keyword
+  description: Validate for print keyword in the code.
+
 # The below hooks are only required or used by a PR build and not required to be used by developers
 - id: prbuild-cfn-lint
   description: Runs cfn-lint on CloudFormation Templates when a pr build is invoked

--- a/hooks/scripts/check-print-keyword.sh
+++ b/hooks/scripts/check-print-keyword.sh
@@ -2,7 +2,7 @@
 
 ## Check for print keyword used for logging in the repository.
 
-count=`grep -r "print" . | wc -l`
+count=`grep -r 'print\s*(' . | wc -l`
 
 if [[ ! $count -ge 1 ]]; then
     echo "ERROR: print statement found in the repository. Please use custom_logger or python logging module and try again !!"

--- a/hooks/scripts/check-print-keyword.sh
+++ b/hooks/scripts/check-print-keyword.sh
@@ -2,7 +2,7 @@
 
 ## Check for print keyword used for logging in the repository.
 
-count=`grep -r "print" | wc -l`
+count=`grep -r "print" . | wc -l`
 
 if [[ ! $count -ge 1 ]]; then
     echo "ERROR: print statement found in the repository. Please use custom_logger or python logging module and try again !!"

--- a/hooks/scripts/check-print-keyword.sh
+++ b/hooks/scripts/check-print-keyword.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## Check for print keyword used for logging in the repository.
+
+count=`grep -r "print" | wc -l`
+
+if [[ ! $count -ge 1 ]]; then
+    echo "ERROR: print statement found in the repository. Please use custom_logger or python logging module and try again !!"
+    exit 1
+else
+    exit 0
+fi

--- a/hooks/scripts/check-print-keyword.sh
+++ b/hooks/scripts/check-print-keyword.sh
@@ -4,7 +4,7 @@
 
 count=`grep -r 'print\s*(' . | wc -l`
 
-if [[ ! $count -ge 1 ]]; then
+if [[ $count -ge 1 ]]; then
     echo "ERROR: print statement found in the repository. Please use custom_logger or python logging module and try again !!"
     exit 1
 else


### PR DESCRIPTION
This feature was to identify print keyword in the code and suggestion to use the python logging module or custom_logger for better clarity of logs with level.
Task Link: https://trello.com/c/WgqUxhbQ/6678-t-create-linting-rule-to-chk-on-logging
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Developer Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated my branch with the latest changes in master.
- [ ] I have communicated with the team any changes that might affect work in progress. 
- [x] I have updated Trello to reflect the current state of the feature. 

## Documentation Checklist
- [x] I have updated the necessary README's
- [ ] I have updated the Runbook

## Description of Changes

Added feature to fail linter when there is a print keyword in the code for the repo.

## Context

As we are moving with the logger module, we are enforcing people to use the logging module instead of print statements as it was very difficult for someone to look into the logs and identify which logs are information, debug, error, and so on. With logging, we can specify the level of the log.

## Description of Testing Process

Tested and verified the regex pattern for print in my local