### PR TITLE
Flag usage of print for python files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,6 +44,7 @@
   name: flake8-lint
   description: '`flake8` is a command-line utility for enforcing style consistency across Python projects.'
   entry: 'flake8 --ignore=E501,W503'
+  additional_dependencies: [flake8-print]
   language: system
   files: \.py$
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,7 +44,6 @@
   name: flake8-lint
   description: '`flake8` is a command-line utility for enforcing style consistency across Python projects.'
   entry: 'flake8 --ignore=E501,W503'
-  additional_dependencies: [flake8-print]
   language: system
   files: \.py$
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ setup:
 	fi \
 	
 	
-	pip install cfn-lint pre-commit flake8 checkov==1.0.580
+	pip install cfn-lint pre-commit flake8 flake8-print checkov==1.0.580
 	pre-commit install
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ setup:
 run:
 	@echo Running pre-commit hook validation using $(HOOK_CONFIG_FILE)...
 	pre-commit clean
-	pre-commit run -c $(HOOK_CONFIG_FILE) --all-files
+	pre-commit run -c $(HOOK_CONFIG_FILE)
 
 clean:
 	@echo Cleaning-up...

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ setup:
 run:
 	@echo Running pre-commit hook validation using $(HOOK_CONFIG_FILE)...
 	pre-commit clean
-	pre-commit run -c $(HOOK_CONFIG_FILE)
+	pre-commit run -c $(HOOK_CONFIG_FILE) --all-files
 
 clean:
 	@echo Cleaning-up...

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,14 @@ setup:
 run:
 	@echo Running pre-commit hook validation using $(HOOK_CONFIG_FILE)...
 	pre-commit clean
-	pre-commit run -c $(HOOK_CONFIG_FILE) --all-files
+
+	if [[ ! -z "$$EVENT_NAME" ]] && [[ "$$EVENT_NAME" == NIGHTLY ]]; then \
+		echo "Running in Nightly Mode"
+		pre-commit run -c $(HOOK_CONFIG_FILE) --all-files;\
+	else \
+		pre-commit run -c $(HOOK_CONFIG_FILE) --from-ref master --to-ref HEAD;\
+	fi \
+
 
 clean:
 	@echo Cleaning-up...

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ run:
 	pre-commit clean
 
 	if [[ ! -z "$$EVENT_NAME" ]] && [[ "$$EVENT_NAME" == NIGHTLY ]]; then \
-		echo "Running in Nightly Mode"
+		echo "Running in Nightly Mode"; \
 		pre-commit run -c $(HOOK_CONFIG_FILE) --all-files;\
 	else \
-		pre-commit run -c $(HOOK_CONFIG_FILE) --from-ref master --to-ref HEAD;\
+		pre-commit run -c $(HOOK_CONFIG_FILE) --from-ref origin/master --to-ref HEAD;\
 	fi \
 
 

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,10 @@ run:
 	@echo Running pre-commit hook validation using $(HOOK_CONFIG_FILE)...
 	pre-commit clean
 
-	if [[ ! -z "$$EVENT_NAME" ]] && [[ "$$EVENT_NAME" == NIGHTLY ]]; then \
-		echo "Running in Nightly Mode"; \
-		pre-commit run -c $(HOOK_CONFIG_FILE) --all-files;\
-	else \
+	if [[ ! -z "$$EVENT_NAME" ]] && [[ "$$EVENT_NAME" == PR ]]; then \
 		pre-commit run -c $(HOOK_CONFIG_FILE) --from-ref origin/master --to-ref HEAD;\
+	else \
+		pre-commit run -c $(HOOK_CONFIG_FILE) --all-files;\
 	fi \
 
 


### PR DESCRIPTION
Linter check to flag usage of print within python files.

Task Link: https://trello.com/c/WgqUxhbQ/6678-t-create-linting-rule-to-chk-on-logging
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Developer Checklist
- [ ] My change requires a change to the documentation.
- [x] I have updated my branch with the latest changes in master.
- [x] I have communicated with the team any changes that might affect work in progress. 
- [ ] I have updated Trello to reflect current state of the feature. 

## Documentation Checklist
- [ ] I have updated the necessary README's
- [ ] I have updated the Runbook

## Description of Changes

- Uses `flake8-print` plugin on top of `flake8` to achieve desired functionality
- Will not block PRs or break devevloper workflows since linter will only run against changed files in PR
- lines/files can be skipped/ignore using standard flake8 ignore rules


## Context
- Improve python codebase by phasing out `print` usage

## Description of Testing Process
- Verified locally
- Ran against template-repo-cf-modules master branch
- Ran against test-branch with change made for python file 
https://internal-commo-jenki-dnef72g28tsg-407778437.us-east-1.elb.amazonaws.com/job/Code-Linter/5392/console
https://github.com/Flux7Labs/template-repo-cf-modules/pull/351

