### PR TITLE
Fix code-linter failures for cfn-lint - pin networkx version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ setup:
 	fi \
 
 	if [[ ! -z "$$EVENT_NAME" ]] && [[ "$$EVENT_NAME" == PR ]]; then \
-		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 networkx==2.4 pre-commit flake8 flake8-print checkov==1.0.580;\
+		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 networkx==2.5 pre-commit flake8 flake8-print checkov==1.0.580;\
 	else \
-		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 networkx==2.4 pre-commit flake8 checkov==1.0.580;\
+		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 networkx==2.5 pre-commit flake8 checkov==1.0.580;\
 	fi \
 	
 	pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ setup:
 	fi \
 
 	if [[ ! -z "$$EVENT_NAME" ]] && [[ "$$EVENT_NAME" == PR ]]; then \
-		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 pre-commit flake8 flake8-print checkov==1.0.580;\
+		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 networkx==2.4 pre-commit flake8 flake8-print checkov==1.0.580;\
 	else \
-		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 pre-commit flake8 checkov==1.0.580;\
+		pip install bc-python-hcl2==0.3.15 cfn-lint==0.47.2 networkx==2.4 pre-commit flake8 checkov==1.0.580;\
 	fi \
 	
 	pre-commit install


### PR DESCRIPTION
<!-- Plase update the GitHub commit summary with a 1-line <80 char desc -->
Task Link: https://trello.com/c/Y5jV1Tj8
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Developer Checklist
- [ ] My change requires a change to the documentation.
- [x] I have updated my branch with the latest changes in master.
- [ ] I have communicated with the team any changes that might affect work in progress. 
- [x] I have updated Trello to reflect current state of the feature. 

## Documentation Checklist
- [ ] I have updated the necessary README's
- [ ] I have updated the Runbook

## Description of Changes
Pinning networkx pkg version to the last known working version. 

## Context
Code-linter is failing for all the cloud formation repositories with the following error. Upon debugging found networkx package got a new release which broke the stuff.
```
Cloudformation Lint......................................................Failed
- hook id: cfn-lint
- exit code: 1

Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/Code-Linter/venv/bin/cfn-lint", line 5, in <module>
    from cfnlint.__main__ import main
  File "/var/lib/jenkins/workspace/Code-Linter/venv/lib/python3.7/site-packages/cfnlint/__init__.py", line 9, in <module>
    from cfnlint.graph import Graph
  File "/var/lib/jenkins/workspace/Code-Linter/venv/lib/python3.7/site-packages/cfnlint/graph.py", line 10, in <module>
    from networkx import networkx
ImportError: cannot import name 'networkx' from 'networkx' (/var/lib/jenkins/workspace/Code-Linter/venv/lib/python3.7/site-packages/networkx/__init__.py)
```

## Description of Testing Process
Validated the code-linter for few repositories from the branch.
https://internal-commo-jenki-dnef72g28tsg-407778437.us-east-1.elb.amazonaws.com/job/Code-Linter/16833/console
https://internal-commo-jenki-dnef72g28tsg-407778437.us-east-1.elb.amazonaws.com/job/Code-Linter/16834/console
https://internal-commo-jenki-dnef72g28tsg-407778437.us-east-1.elb.amazonaws.com/job/Code-Linter/16835/console